### PR TITLE
Refactor health check into modular scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ claude mcp list
 - フォールバックとして VS Code Secrets でも設定可能
 - `devcontainer.local.json` で Mount や `remoteEnv` を追加するとホスト固有設定を安全に共有できます（ `.gitignore` 済み）
 
+### 4.5 環境ヘルスチェック
+コンテナ起動直後やトラブルシューティング時は、ヘルスチェックを実施すると前提条件の崩れを素早く検知できます。
+
+```bash
+bash scripts/health/check-environment.sh         # フルチェック（既定）
+bash scripts/health/check-environment.sh --quick # 主要項目のみ
+bash scripts/health/check-environment.sh --json  # JSON サマリ出力
+```
+
+- クリティカルな検査失敗で終了コード 1、警告のみで 2、問題なしは 0 を返します。
+- `--list-checks` で利用可能なチェック ID を表示し、`--skip <id>` で特定の検査を除外できます（例: `--skip serena-ready`）。
+- チェック内容の詳細は `scripts/health/README.md` を参照してください。
+
 ## 5. カスタマイズのヒント
 - Filesystem MCP のアクセス範囲は `post-create-setup.sh` 内の `$ROOT` を変更して調整
 - Serena の `--context` や `--project` オプションも同スクリプトで変更可能

--- a/scripts/health/README.md
+++ b/scripts/health/README.md
@@ -1,0 +1,45 @@
+# Claym ヘルスチェック スクリプト
+
+このディレクトリには、Claym の開発コンテナをビルド直後や起動直後に検証するためのヘルスチェックがまとまっています。
+
+ヘルスチェックはモジュール構成になっており、`lib/` に実行基盤と共通ヘルパー、`checks/` に個別の診断（システム、ツールチェーン、MCP など）を配置しています。新しいチェックを追加したい場合は、`checks/` にファイルを作成して `register_check` を呼び出すだけで組み込めます。
+
+## check-environment.sh
+
+ルート README で説明している前提条件を低コストで検証します。
+
+- Ubuntu 24.04 ベースとタイムゾーン設定の確認
+- ワークスペースおよび ImageSorcery ログディレクトリが `vscode` ユーザー所有であることの確認
+- 主要 CLI (`claude`, `codex`, `gemini`, `uv`, `npx`, `pipx`, `rg` など) の存在チェック
+- CLI バージョン取得によるドリフト検知
+- Claude / Codex / Gemini に対する既定 MCP 登録の有無確認
+- Serena・Playwright・pipx 管理の MCP 資産のスポットチェック
+- コンテナにエクスポートされている API キー一覧の表示
+- `safe.directory` 設定と ImageSorcery ログの参照可否の確認
+
+### 使い方
+
+```bash
+# フルチェック（既定）
+bash scripts/health/check-environment.sh
+
+# 起動後の簡易チェック
+bash scripts/health/check-environment.sh --quick
+
+# JSON 形式のサマリ出力
+bash scripts/health/check-environment.sh --json
+
+# チェックID一覧を表示
+bash scripts/health/check-environment.sh --list-checks
+
+# 既知の失敗チェックをスキップ
+bash scripts/health/check-environment.sh --skip serena-ready
+```
+
+終了コードの意味:
+
+- `0`: クリティカルチェックがすべて成功
+- `1`: クリティカルチェックに失敗あり
+- `2`: 致命的ではない警告のみ
+
+オプションは併用可能です（例: `--quick --json`）。CI や devcontainer フックに組み込むほか、手動診断にも利用できます。

--- a/scripts/health/check-environment.sh
+++ b/scripts/health/check-environment.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Claym dev container health check entry point
+
+set -Eeuo pipefail
+
+readonly HEALTH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "${HEALTH_DIR}/../.." && pwd)"
+readonly HEALTH_LIB_DIR="${HEALTH_DIR}/lib"
+
+# ライブラリの読み込み
+# shellcheck source=lib/common.sh
+source "${HEALTH_LIB_DIR}/common.sh"
+# shellcheck source=lib/args.sh
+source "${HEALTH_LIB_DIR}/args.sh"
+# shellcheck source=lib/core.sh
+source "${HEALTH_LIB_DIR}/core.sh"
+
+parse_args "$@"
+
+# チェックモジュールをロード
+for module in "${HEALTH_DIR}/checks"/*.sh; do
+  # shellcheck disable=SC1090
+  source "$module"
+done
+
+if [[ "$LIST_CHECKS" == true ]]; then
+  list_checks
+  exit 0
+fi
+
+run_all_checks
+exit $?

--- a/scripts/health/checks/mcp.sh
+++ b/scripts/health/checks/mcp.sh
@@ -1,0 +1,136 @@
+# shellcheck shell=bash
+# MCP や関連サービスのチェック
+
+collect_mcp_list() {
+  local cli="$1" output=""
+  case "$cli" in
+    claude) output=$(claude mcp list 2>/dev/null || true) ;;
+    codex) output=$(codex mcp list 2>/dev/null || true) ;;
+    gemini) output=$(gemini mcp list 2>/dev/null || true) ;;
+  esac
+  printf '%s' "$output"
+}
+
+check_mcp_registrations() {
+  local required=(serena playwright markitdown imagesorcery filesystem)
+  local optional=(context7)
+  local summary=()
+  local cli
+  local missing_global=()
+  local warn_global=()
+
+  for cli in claude codex gemini; do
+    if ! have "$cli"; then
+      warn_global+=("$cli (CLI missing)")
+      continue
+    fi
+    local list
+    list=$(collect_mcp_list "$cli")
+    if [[ -z "$list" ]]; then
+      warn_global+=("$cli (no MCP entries detected)")
+      continue
+    fi
+    local missing=()
+    local name
+    for name in "${required[@]}"; do
+      if ! grep -qi "${name}" <<<"$list"; then
+        missing+=("$name")
+      fi
+    done
+    if ((${#missing[@]})); then
+      summary+=("$cli missing: ${missing[*]}")
+      missing_global+=("$cli")
+    else
+      summary+=("$cli ok")
+    fi
+    for name in "${optional[@]}"; do
+      if ! grep -qi "${name}" <<<"$list"; then
+        warn_global+=("$cli missing optional ${name}")
+      fi
+    done
+  done
+
+  if ((${#missing_global[@]})); then
+    set_result "FAIL" "Missing MCP registrations (${summary[*]})" "Re-run post-create setup to re-register MCPs"
+    return
+  fi
+  if ((${#warn_global[@]})); then
+    set_result "WARN" "Warnings: ${warn_global[*]}" "Add optional MCPs if required for your workflow"
+    return
+  fi
+  set_result "PASS" "Claude, Codex, and Gemini MCP lists contain required entries" ""
+}
+
+check_serena_ready() {
+  local dir="/opt/serena"
+  if [[ ! -d "$dir" ]]; then
+    set_result "FAIL" "Serena directory missing at $dir" "Verify clone step in Dockerfile completed"
+    return
+  fi
+  local owner
+  if ! owner=$(stat -c '%U' "$dir" 2>/dev/null); then
+    set_result "WARN" "Unable to read /opt/serena ownership" "Check permissions manually"
+    return
+  fi
+  if [[ "$owner" != "vscode" ]]; then
+    set_result "WARN" "Serena directory owned by $owner" "Run post-start script or chown to vscode"
+    return
+  fi
+  if ! uv run --directory "$dir" serena --help >/dev/null 2>&1; then
+    set_result "WARN" "Serena CLI failed to respond" "Run 'uv run --directory /opt/serena serena --help' manually for details"
+    return
+  fi
+  set_result "PASS" "Serena repository ready and executable" ""
+}
+
+check_playwright_assets() {
+  local cache_dir="${HOME}/.cache/ms-playwright"
+  if [[ ! -d "$cache_dir" ]]; then
+    set_result "WARN" "Playwright cache dir missing at $cache_dir" "Run 'npx playwright install chromium --with-deps'"
+    return
+  fi
+  local chromium_dir
+  chromium_dir=$(find "$cache_dir" -maxdepth 1 -type d -name 'chromium-*' | head -n1 || true)
+  if [[ -z "$chromium_dir" ]]; then
+    set_result "WARN" "No chromium bundle found in $cache_dir" "Re-run Playwright install step"
+    return
+  fi
+  set_result "PASS" "Playwright Chromium assets present" ""
+}
+
+check_log_diagnostics() {
+  local dirs
+  if ! mapfile -t dirs < <(imagesorcery_log_dirs); then
+    set_result "WARN" "Unable to resolve ImageSorcery log directories" "Run post-create setup to regenerate logs"
+    return
+  fi
+  local latest_file=""
+  local dir
+  for dir in "${dirs[@]}"; do
+    [[ -z "$dir" ]] && continue
+    if [[ -d "$dir" ]]; then
+      local candidate
+      candidate=$(ls -1t "$dir"/*.log 2>/dev/null | head -n1 || true)
+      if [[ -n "$candidate" ]]; then
+        latest_file="$candidate"
+        break
+      fi
+    fi
+  done
+  if [[ -z "$latest_file" ]]; then
+    set_result "WARN" "No ImageSorcery log file found" "Run an ImageSorcery MCP command to generate logs"
+    return
+  fi
+  local tail_output
+  tail_output=$(tail -n5 "$latest_file" 2>/dev/null || true)
+  if [[ -z "$tail_output" ]]; then
+    set_result "WARN" "Failed to read $latest_file" "Check file permissions"
+    return
+  fi
+  set_result "PASS" "ImageSorcery log available at $latest_file" "$tail_output"
+}
+
+register_check "mcp-registrations" "MCP registrations" true true check_mcp_registrations
+register_check "serena-ready" "Serena readiness" false false check_serena_ready
+register_check "playwright-assets" "Playwright assets" false false check_playwright_assets
+register_check "log-diagnostics" "ImageSorcery logs" false false check_log_diagnostics

--- a/scripts/health/checks/system.sh
+++ b/scripts/health/checks/system.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# システム関連のチェック
+
+check_system_basics() {
+  local os_release=/etc/os-release
+  local os_name="" version="" tz_file="/etc/timezone" tz_value=""
+
+  if [[ -f "$os_release" ]]; then
+    os_name=$(grep '^NAME=' "$os_release" | cut -d'=' -f2- | tr -d '"')
+    version=$(grep '^VERSION_ID=' "$os_release" | cut -d'=' -f2- | tr -d '"')
+  fi
+
+  if [[ "$os_name" != "Ubuntu" || "$version" != "24.04" ]]; then
+    set_result "FAIL" "Detected ${os_name:-unknown} ${version:-unknown}; expected Ubuntu 24.04" "Rebuild the dev container from the provided Dockerfile"
+    return
+  fi
+
+  if [[ -f "$tz_file" ]]; then
+    tz_value=$(<"$tz_file")
+  fi
+  local expected_tz="${TZ:-Asia/Tokyo}"
+  if [[ -n "$tz_value" && "$tz_value" != "$expected_tz" ]]; then
+    set_result "WARN" "Timezone reported as $tz_value (expected $expected_tz)" "Update /etc/timezone or TZ env if this is intentional"
+    return
+  fi
+
+  set_result "PASS" "Ubuntu 24.04 with timezone ${tz_value:-$expected_tz}" ""
+}
+
+check_workspace_permissions() {
+  local owner
+  if ! owner=$(stat -c '%U' "$REPO_ROOT" 2>/dev/null); then
+    set_result "FAIL" "Unable to read workspace ownership" "Verify permissions for $REPO_ROOT"
+    return
+  fi
+  if [[ "$owner" != "vscode" ]]; then
+    set_result "FAIL" "Workspace owned by $owner (expected vscode)" "Run 'sudo chown -R vscode:vscode $REPO_ROOT'"
+    return
+  fi
+
+  local missing=()
+  if mapfile -t log_dirs < <(imagesorcery_log_dirs); then
+    local dir dir_owner
+    for dir in "${log_dirs[@]}"; do
+      [[ -z "$dir" ]] && continue
+      if [[ ! -d "$dir" ]]; then
+        missing+=("$dir")
+        continue
+      fi
+      if ! dir_owner=$(stat -c '%U' "$dir" 2>/dev/null); then
+        missing+=("$dir (stat failed)")
+        continue
+      fi
+      if [[ "$dir_owner" != "vscode" ]]; then
+        set_result "WARN" "ImageSorcery log dir $dir owned by $dir_owner" "Run post-start script or fix ownership to vscode"
+        return
+      fi
+    done
+    if ((${#missing[@]} > 0)); then
+      set_result "WARN" "ImageSorcery log dirs missing: ${missing[*]}" "Re-run post-start script to create log directories"
+      return
+    fi
+  fi
+
+  set_result "PASS" "Workspace and ImageSorcery logs owned by vscode" ""
+}
+
+register_check "system-basics" "System basics" true true check_system_basics
+register_check "workspace-perms" "Workspace permissions" true true check_workspace_permissions

--- a/scripts/health/checks/tooling.sh
+++ b/scripts/health/checks/tooling.sh
@@ -1,0 +1,122 @@
+# shellcheck shell=bash
+# ツールチェーン関連のチェック
+
+check_cli_paths() {
+  local required=(claude codex gemini uv npx npm pipx rg)
+  local missing=()
+  local cmd
+  declare -A seen=()
+  for cmd in "${required[@]}"; do
+    [[ -n "${seen[$cmd]:-}" ]] && continue
+    seen[$cmd]=1
+    if ! have "$cmd"; then
+      missing+=("$cmd")
+    fi
+  done
+  if ((${#missing[@]})); then
+    set_result "FAIL" "Missing commands: ${missing[*]}" "Rebuild container or install listed CLI tools"
+    return
+  fi
+  set_result "PASS" "All required CLI commands are on PATH" ""
+}
+
+check_cli_versions() {
+  local commands=(
+    "claude --version"
+    "codex --version"
+    "gemini --version"
+    "uv --version"
+    "npm --version"
+    "pipx --version"
+  )
+  local outputs=()
+  local cmd
+  for cmd in "${commands[@]}"; do
+    local binary=${cmd%% *}
+    if ! have "$binary"; then
+      outputs+=("$binary: <missing>")
+      continue
+    fi
+    if ! out=$(env LC_ALL=C $cmd 2>/dev/null | head -n1); then
+      outputs+=("$binary: <unavailable>")
+    else
+      outputs+=("$binary: $out")
+    fi
+  done
+  local missing_versions=()
+  for line in "${outputs[@]}"; do
+    if [[ "$line" == *"<missing>"* || "$line" == *"<unavailable>"* ]]; then
+      missing_versions+=("$line")
+    fi
+  done
+  if ((${#missing_versions[@]})); then
+    set_result "WARN" "Unable to read versions for: ${missing_versions[*]}" "Confirm commands support --version or update this check"
+  else
+    set_result "PASS" "Collected CLI versions" "${outputs[*]}"
+  fi
+}
+
+check_pipx_packages() {
+  if ! have pipx; then
+    set_result "WARN" "pipx not available" "Ensure pipx is installed"
+    return
+  fi
+  local expected=(markitdown-mcp imagesorcery-mcp mcp-github)
+  local list
+  if ! list=$(pipx list 2>/dev/null); then
+    set_result "WARN" "Failed to read pipx environments" "Review pipx installation"
+    return
+  fi
+  local missing=()
+  local pkg
+  for pkg in "${expected[@]}"; do
+    if ! grep -q "$pkg" <<<"$list"; then
+      missing+=("$pkg")
+    fi
+  done
+  if ((${#missing[@]})); then
+    set_result "WARN" "pipx packages missing: ${missing[*]}" "Re-run Docker image build or install via pipx"
+    return
+  fi
+  set_result "PASS" "pipx packages installed" ""
+}
+
+check_api_keys() {
+  local vars=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GITHUB_TOKEN FIRECRAWL_API_KEY)
+  local present=()
+  local absent=()
+  local var
+  for var in "${vars[@]}"; do
+    if [[ -n "${!var:-}" ]]; then
+      present+=("$var")
+    else
+      absent+=("$var")
+    fi
+  done
+  local msg="Set: ${present[*]:-none}; Unset: ${absent[*]:-none}"
+  if ((${#present[@]} == 0)); then
+    set_result "WARN" "$msg" "Export the API keys required for desired MCPs"
+  else
+    set_result "PASS" "$msg" ""
+  fi
+}
+
+check_git_safe_directory() {
+  local entries
+  entries=$(git config --system --get-all safe.directory 2>/dev/null || true)
+  if [[ -z "$entries" ]]; then
+    set_result "WARN" "safe.directory not configured" "Run 'sudo git config --system --add safe.directory $REPO_ROOT'"
+    return
+  fi
+  if ! grep -Fxq "$REPO_ROOT" <<<"$entries"; then
+    set_result "WARN" "safe.directory missing $REPO_ROOT" "Add workspace path to system git config"
+    return
+  fi
+  set_result "PASS" "git safe.directory includes workspace path" ""
+}
+
+register_check "cli-paths" "CLI availability" true true check_cli_paths
+register_check "cli-versions" "CLI versions" false false check_cli_versions
+register_check "pipx-packages" "pipx packages" false false check_pipx_packages
+register_check "api-keys" "API keys" false true check_api_keys
+register_check "git-safe-directory" "Git safe.directory" false false check_git_safe_directory

--- a/scripts/health/lib/args.sh
+++ b/scripts/health/lib/args.sh
@@ -1,0 +1,79 @@
+# shellcheck shell=bash
+# 引数解析とオプション管理
+
+RUN_MODE="full"
+OUTPUT_FORMAT="text"
+USE_COLOR=${USE_COLOR:-true}
+LIST_CHECKS=false
+SKIP_CHECKS=()
+
+show_help() {
+  cat <<'EOF'
+Claym health check
+Usage: check-environment.sh [--quick] [--full] [--json] [--list-checks] [--skip <id>] [--no-color]
+
+Options:
+  --quick         Run the minimal fast checks (default is full suite)
+  --full          Run all checks (default)
+  --json          Output machine-readable JSON summary only (no text)
+  --list-checks   Print available check IDs and exit
+  --skip <id>     Skip a specific check (can be repeated)
+  --no-color      Disable ANSI colors in text output
+  -h, --help      Display this help
+EOF
+}
+
+parse_args() {
+  while (($#)); do
+    case "$1" in
+      --quick)
+        RUN_MODE="quick"
+        ;;
+      --full)
+        RUN_MODE="full"
+        ;;
+      --json)
+        OUTPUT_FORMAT="json"
+        ;;
+      --list-checks)
+        LIST_CHECKS=true
+        ;;
+      --no-color)
+        USE_COLOR=false
+        ;;
+      --skip)
+        if [[ $# -lt 2 ]]; then
+          err "--skip requires an argument"
+          exit 2
+        fi
+        SKIP_CHECKS+=("$2")
+        shift
+        ;;
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        err "Unknown option: $1"
+        show_help
+        exit 2
+        ;;
+    esac
+    shift
+  done
+}
+
+is_skipped() {
+  local id="$1"
+  local skip
+  for skip in "${SKIP_CHECKS[@]}"; do
+    if [[ "$skip" == "$id" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/scripts/health/lib/common.sh
+++ b/scripts/health/lib/common.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# 共通ユーティリティ: ログ関数や色指定などを提供
+
+: "${USE_COLOR:=true}"
+
+if [[ -z ${HEALTH_LIB_DIR+x} ]]; then
+  HEALTH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+if [[ -z ${REPO_ROOT+x} ]]; then
+  REPO_ROOT="$(cd "${HEALTH_LIB_DIR}/../.." && pwd)"
+fi
+
+LOG_HELPERS="${REPO_ROOT}/.devcontainer/scripts/helpers/logging.sh"
+IMAGESORCERY_HELPERS="${REPO_ROOT}/.devcontainer/scripts/helpers/imagesorcery.sh"
+
+if [[ -f "${LOG_HELPERS}" ]]; then
+  # shellcheck disable=SC1090
+  source "${LOG_HELPERS}"
+else
+  info() { printf '[INFO] %s\n' "$*"; }
+  warn() { printf '[WARN] %s\n' "$*"; }
+  err()  { printf '[ERR ] %s\n' "$*"; }
+  have() { command -v "$1" >/dev/null 2>&1; }
+fi
+
+if [[ -f "${IMAGESORCERY_HELPERS}" ]]; then
+  # shellcheck disable=SC1090
+  source "${IMAGESORCERY_HELPERS}"
+else
+  imagesorcery_log_dirs() { return 0; }
+fi
+
+ANSI_GREEN='\033[1;32m'
+ANSI_YELLOW='\033[1;33m'
+ANSI_RED='\033[1;31m'
+ANSI_RESET='\033[0m'
+
+print_status() {
+  local status="$1" label="$2"
+  shift 2
+  local message="$*"
+  local color=""
+
+  if [[ "${USE_COLOR}" == true ]]; then
+    case "$status" in
+      PASS) color="$ANSI_GREEN" ;;
+      WARN) color="$ANSI_YELLOW" ;;
+      FAIL) color="$ANSI_RED" ;;
+    esac
+  fi
+
+  printf '%b[%s]%b %s: %s\n' "$color" "$status" "$ANSI_RESET" "$label" "$message"
+}

--- a/scripts/health/lib/core.sh
+++ b/scripts/health/lib/core.sh
@@ -1,0 +1,159 @@
+# shellcheck shell=bash
+# チェック登録・実行の中核ロジック
+
+declare -gA CHECK_LABEL=()
+declare -gA CHECK_CRITICAL=()
+declare -gA CHECK_QUICK=()
+declare -gA CHECK_FN=()
+declare -ga CHECK_ORDER=()
+
+declare -ga RESULTS=()
+FAILED_CRITICAL=false
+FAILED_OPTIONAL=false
+
+CHECK_STATUS="PASS"
+CHECK_MESSAGE=""
+CHECK_HINT=""
+
+register_check() {
+  local id="$1" label="$2" critical="$3" quick="$4" fn="$5"
+  CHECK_ORDER+=("$id")
+  CHECK_LABEL["$id"]="$label"
+  CHECK_CRITICAL["$id"]=$critical
+  CHECK_QUICK["$id"]=$quick
+  CHECK_FN["$id"]=$fn
+}
+
+set_result() {
+  CHECK_STATUS="$1"
+  CHECK_MESSAGE="$2"
+  CHECK_HINT="$3"
+}
+
+should_skip_check() {
+  local id="$1"
+  if is_skipped "$id"; then
+    return 0
+  fi
+  if [[ "$RUN_MODE" == "quick" && "${CHECK_QUICK[$id]}" != true ]]; then
+    return 0
+  fi
+  return 1
+}
+
+list_checks() {
+  printf '利用可能なチェック ID ( --skip で指定可能 )\n'
+  local id
+  for id in "${CHECK_ORDER[@]}"; do
+    printf '  %-20s %s\n' "$id" "${CHECK_LABEL[$id]}"
+  done
+}
+
+run_check() {
+  local id="$1"
+  local label="${CHECK_LABEL[$id]}"
+  local critical="${CHECK_CRITICAL[$id]}"
+  local fn="${CHECK_FN[$id]}"
+
+  CHECK_STATUS="PASS"
+  CHECK_MESSAGE=""
+  CHECK_HINT=""
+
+  "$fn"
+
+  if [[ "$critical" != true && "$CHECK_STATUS" == "FAIL" ]]; then
+    CHECK_STATUS="WARN"
+  fi
+
+  if [[ "$CHECK_STATUS" == "FAIL" ]]; then
+    FAILED_CRITICAL=true
+  elif [[ "$CHECK_STATUS" == "WARN" ]]; then
+    FAILED_OPTIONAL=true
+  fi
+
+  local display_message="$CHECK_MESSAGE"
+  if [[ -n "$CHECK_HINT" ]]; then
+    display_message+=" (hint: $CHECK_HINT)"
+  fi
+
+  RESULTS+=("$id|$CHECK_STATUS|$CHECK_MESSAGE|$CHECK_HINT")
+
+  if [[ "$OUTPUT_FORMAT" == "text" ]]; then
+    print_status "$CHECK_STATUS" "$label" "$display_message"
+  fi
+}
+
+emit_json_summary() {
+  python3 - "$SUMMARY_STATUS" "$SUMMARY_MESSAGE" "$FAILED_CRITICAL" "$FAILED_OPTIONAL" "${RESULTS[@]}" <<'PY'
+import json, sys
+summary_status, summary_message, critical_failed, optional_failed = sys.argv[1:5]
+results_data = sys.argv[5:]
+critical_failed = critical_failed.lower() == "true"
+optional_failed = optional_failed.lower() == "true"
+checks = []
+for line in results_data:
+    line = line.rstrip("\n")
+    if not line:
+        continue
+    parts = line.split("|")
+    while len(parts) < 4:
+        parts.append("")
+    check_id, status, message, hint = parts[:4]
+    checks.append({
+        "id": check_id,
+        "status": status,
+        "message": message,
+        "hint": hint,
+    })
+summary = {
+    "status": summary_status,
+    "message": summary_message,
+    "critical_failed": critical_failed,
+    "warnings_present": optional_failed,
+}
+json.dump({"summary": summary, "checks": checks}, sys.stdout)
+print()
+PY
+}
+
+summarize_results() {
+  if [[ "$FAILED_CRITICAL" == true ]]; then
+    SUMMARY_STATUS="FAIL"
+    SUMMARY_MESSAGE="Critical checks failed"
+  elif [[ "$FAILED_OPTIONAL" == true ]]; then
+    SUMMARY_STATUS="WARN"
+    SUMMARY_MESSAGE="Warnings detected (non-critical)"
+  else
+    SUMMARY_STATUS="PASS"
+    SUMMARY_MESSAGE="All checks passed"
+  fi
+}
+
+run_all_checks() {
+  RESULTS=()
+  FAILED_CRITICAL=false
+  FAILED_OPTIONAL=false
+
+  local id
+  for id in "${CHECK_ORDER[@]}"; do
+    if should_skip_check "$id"; then
+      continue
+    fi
+    run_check "$id"
+  done
+
+  summarize_results
+
+  if [[ "$OUTPUT_FORMAT" == "text" ]]; then
+    print_status "$SUMMARY_STATUS" "Summary" "$SUMMARY_MESSAGE"
+  else
+    emit_json_summary
+  fi
+
+  if [[ "$FAILED_CRITICAL" == true ]]; then
+    return 1
+  elif [[ "$FAILED_OPTIONAL" == true ]]; then
+    return 2
+  fi
+  return 0
+}


### PR DESCRIPTION
## 概要
- `scripts/health/` をモジュール構成に再編し、エントリーポイント・共通ライブラリ・チェックロジックを分離
- `--list-checks` オプションを追加して利用可能なチェック ID を一覧表示、`--skip` の指定根拠を分かりやすく改良
- README 類を更新し、新しい実行方法とオプションを追記

## テスト
- scripts/health/check-environment.sh --list-checks
- scripts/health/check-environment.sh --full --skip mcp-registrations
- scripts/health/check-environment.sh --quick（WARNはAPIキー未設定やMCP未登録などコンテナ環境依存）
