### PR TITLE
Add CI workflow for environment health check

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -23,8 +23,8 @@ jobs:
           runCmd: |
             scripts/health/check-environment.sh --json > health-check-result.json
             cat health-check-result.json
-            # Exit with the same code as the health check
-            scripts/health/check-environment.sh --no-color
+            # Run health check and allow warnings (exit code 2)
+            scripts/health/check-environment.sh --no-color || [ $? -eq 2 ]
 
       - name: Upload health check results
         if: always()

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,35 @@
+name: Environment Health Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run health check in dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            scripts/health/check-environment.sh --json > health-check-result.json
+            cat health-check-result.json
+            # Exit with the same code as the health check
+            scripts/health/check-environment.sh --no-color
+
+      - name: Upload health check results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: health-check-results
+          path: health-check-result.json
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ docker-compose.override.yml
 *.bak
 *.backup
 *~
+
+# serena
+.serena


### PR DESCRIPTION
## Summary
- GitHub Actions ワークフローを追加して、PR マージ前に環境ヘルスチェックを実行
- `scripts/health/check-environment.sh` を使用して開発環境の整合性を検証
- Dev Container 環境で CI を実行

## Changes
- `.github/workflows/health-check.yml`: ヘルスチェックワークフローを追加
- `.gitignore`: `.serena` ディレクトリを追加

## CI Behavior
- **トリガー**: PR 作成/更新時、main ブランチへの push 時
- **環境**: devcontainers/ci を使用して Dev Container 内で実行
- **成功条件**:
- ✅ すべてのチェックが PASS（終了コード 0）
- ✅ 警告あり（終了コード 2）- 非クリティカルな問題は許容
- ❌ クリティカル失敗（終了コード 1）のみ CI 失敗

## Test Plan
- [x] ローカルで `check-environment.sh` を実行して動作確認
- [x] 通常モードと JSON モードの両方をテスト
- [ ] GitHub Actions でワークフローが正常に実行されることを確認
- [ ] アーティファクト（health-check-results）が正しくアップロードされることを確認

