### PR TITLE
fix: Dockerfile のプラットフォーム指定とバイナリURL修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@
 # Oh My Zsh も含めています。使い方の詳細は README または devcontainer.json を参照してください。
 ##############################
 
-FROM ubuntu:24.04
+FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 # 既定の作業ディレクトリとして /workspace を使用します。
@@ -322,7 +322,7 @@ RUN set -eux \
 
 # [5/11] difftastic (構文認識diff) v0.67.0
 RUN set -eux \
-    && curl -sfLO "https://github.com/Wilfred/difftastic/releases/download/0.67.0/difft-x86_64-unknown-linux-gnu.tar.gz" \
+    && curl -sfLO "https://github.com/Wilfred/difftastic/releases/download/0.67.0/difft-x86_64-unknown-linux-musl.tar.gz" \
     && tar -xzf difft-*.tar.gz -C /usr/local/bin \
     && rm difft-*.tar.gz
 


### PR DESCRIPTION
## 概要
Dockerfile のビルド互換性とバイナリ取得の安定性を改善します。

## 変更内容
- `FROM` に `--platform=linux/amd64` を明示し、ARM ホスト（Apple Silicon 等）でも正しくビルドできるように修正
- difftastic のダウンロード URL を `gnu` → `musl` バイナリに変更（コンテナ環境との互換性向上）
- ファイル末尾の改行を追加

## テスト方法
- [ ] コンテナのビルドが成功すること
- [ ] `difft --version` が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)